### PR TITLE
fixed install cmd on windows

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -82,7 +82,8 @@ export async function gitInit(dest: string) {
 export async function nodeInstall(dest: string) {
   chdir(dest);
 
-  const bin = which.sync('yarnpkg', { nothrow: true });
-  const cmd = bin ? 'yarnpkg' : 'npm';
+  const yarn = which.sync('yarnpkg', { nothrow: true });
+  const npm = which.sync('npm', { nothrow: true });
+  const cmd = yarn ? yarn : (npm ? npm : 'npm');
   await runCommand(cmd, ['install']);
 }


### PR DESCRIPTION
# Problem

When run on Windows and agreed to install dependencies, a 'ENOENT' error is thrown.

# Cause

The `child_process.spawn` method does not allow alias somehow, e.g. yarn.cmd aliased to yarn. A reference of this issue can be found [here](https://github.com/nodejs/node/issues/3675)

# Fix

simply replacing the 'yarnpkg' and 'npm' variables with the full-pathed executable fixes this.