### PR TITLE
feat: Use package.json's main to get esbuild's outfile

### DIFF
--- a/template/esbuild.mjs
+++ b/template/esbuild.mjs
@@ -1,4 +1,9 @@
+import fs from "fs";
 import * as esbuild from 'esbuild';
+
+const loadJSON = (path) =>
+  JSON.parse(fs.readFileSync(new URL(path, import.meta.url)));
+const data = loadJSON("package.json");
 
 const options = {
   entryPoints: ['src/index.ts'],
@@ -9,7 +14,7 @@ const options = {
   external: ['coc.nvim'],
   platform: 'node',
   target: 'node18',
-  outfile: 'lib/index.js',
+  outfile: data.main,
 };
 
 if (process.argv.length > 2 && process.argv[2] === '--watch') {


### PR DESCRIPTION
Refer https://stackoverflow.com/questions/70106880/err-import-assertion-type-missing-for-import-of-json-file/73747606#73747606
